### PR TITLE
Start body w/class loading - page hidden pre-load

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,7 +4,7 @@
     <title>{{ block "title" . }}{{ .Site.Title }}{{ end }}</title>
 {{ partial "head.html" . }}
 </head>
-<body>
+<body class="loading">
         
     <div id="wrapper">
 


### PR DESCRIPTION
When I view your demo site, or when I build a site locally, I catch a glimpse of images at the wrong size and laid out improperly, and not completely loaded, before the page flashes to black again and the loading animation displays.  I believe this is because jQuery (or similar) is applying the "loading" class to body only after the JS starts executing, and the execution starts sufficiently late in page-load to cause the glimpse.

This mod adds the loading class to body from the start.  The CSS describing the properties of "loading" gets loaded early, so as soon as the thumb divs load, they are hidden.  I've tested on Chrome (only) and not seen any negative side effects.